### PR TITLE
Update/contributors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ TumorTrace/
 ```
 
 ## Contributor
+A big shoutout and heartfelt thanks to all our amazing contributors for their incredible efforts and dedication! This project wouldn’t be where it is without you.💖
+
 
 <a href="https://github.com/thatgirlAnansi/TumorTrace/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=thatgirlAnansi/TumorTrace" />

--- a/README.md
+++ b/README.md
@@ -68,4 +68,6 @@ TumorTrace/
 
 ## Contributor
 
-Garv Kumar
+<a href="https://github.com/thatgirlAnansi/TumorTrace/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=thatgirlAnansi/TumorTrace" />
+</a>


### PR DESCRIPTION
fixes: #12 

This PR introduces a new section called `Contributors` to acknowledge and celebrate the efforts of everyone who has contributed to this project. The contributors are dynamically showcased using an image generated by [Contrib Rocks](https://contrib.rocks/), which creates a visually appealing representation of the contributors' GitHub profiles.

This addition not only highlights the collaborative spirit of the project but also encourages new contributors to join by recognizing the value of community involvement.